### PR TITLE
Create a page to view all existing links

### DIFF
--- a/flags.go
+++ b/flags.go
@@ -50,6 +50,8 @@ var (
 		return b
 	}(), "Automatically alias the bind IP address to the loopback interface")
 	flagHostname = flag.String("hostname", build.DefaultHostname, "The hostname to add to /etc/hosts for --auto mode (resolvable to the bind address)")
+
+	flagAddLinkUrl = flag.String("add-link-url", build.DefaultAddLinkUrl, "The url to add a new golink. If set a link will be displayed when a golink is not found.")
 )
 
 func init() {

--- a/http.go
+++ b/http.go
@@ -104,7 +104,11 @@ func (g *goHttp) handleRoot() error {
 }
 
 func (g *goHttp) handleView(db *LinkDB) error {
-	return executeTmpl(g.W, http.StatusOK, " - View", "view.tmpl", db.links)
+	data := struct {
+		Links  map[string]Link
+		Prefix string
+	}{db.links, *flagHostname}
+	return executeTmpl(g.W, http.StatusOK, " - View", "view.tmpl", data)
 }
 
 func (g *goHttp) handleLink(name string, l *Link, chainUrl string) error {

--- a/http.go
+++ b/http.go
@@ -28,6 +28,8 @@ func serveHttp(ctx context.Context, db *LinkDB, hostnames []string) error {
 				return g.handleRoot()
 			case p == "_/pref":
 				return g.handlePref()
+			case p == "_/view":
+				return g.handleView(db)
 			case p == "favicon.ico":
 				fallthrough
 			case strings.HasPrefix(p, ".well-known"):
@@ -99,6 +101,10 @@ func (g *goHttp) handleRoot() error {
 		CanChain   bool
 	}{g.getPref("no-redirect", "0"), g.getPref("no-chain", "0"), *flagAddLinkUrl, true || *flagChain != ""}
 	return executeTmpl(g.W, http.StatusOK, "", "index.tmpl", data)
+}
+
+func (g *goHttp) handleView(db *LinkDB) error {
+	return executeTmpl(g.W, http.StatusOK, " - View", "view.tmpl", db.links)
 }
 
 func (g *goHttp) handleLink(name string, l *Link, chainUrl string) error {

--- a/http.go
+++ b/http.go
@@ -2,18 +2,13 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
 	"slices"
 	"strings"
 	"time"
-
-	"github.com/ebnull/gohome/build"
 )
-
-var flagAddLinkUrl = flag.String("add-link-url", build.DefaultAddLinkUrl, "The url to add a new golink. If set a link will be displayed when a golink is not found.")
 
 func serveHttp(ctx context.Context, db *LinkDB, hostnames []string) error {
 	http.HandleFunc("/", httpErrorWrap(

--- a/templates/header.tmpl
+++ b/templates/header.tmpl
@@ -19,14 +19,6 @@
         font-family: monospace;
         white-space: pre;
     }
-    th:has(+ td) {
-        text-align: left;
-    }
-    tr td:nth-child(2) {
-        font-family: monospace;
-        white-space: pre;
-        text-align: center;
-    }
     td,th {
         padding: 5px;
     }

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -1,6 +1,17 @@
+<style>
+    tr td:nth-child(2) {
+        font-family: monospace;
+        white-space: pre;
+        text-align: center;
+    }
+    th:has(+ td) {
+        text-align: left;
+    }
+</style>
 <h1>gohome</h1>
 <p>The local go link redirector</p>
 {{if .AddLinkUrl}}<p><a href="{{.AddLinkUrl}}">Add a new link</a></p>{{end}}
+<p><a href="_/view">View all links</a></p>
 <div id="prefs">
 <table><tr><th>Pref</th><th>Value</th><th></th><th>Description</th></tr>
 <tr>

--- a/templates/view.tmpl
+++ b/templates/view.tmpl
@@ -1,0 +1,26 @@
+<style>
+    tr td {
+        font-family: monospace;
+        white-space: pre;
+    }
+    th {
+        text-align: left;
+    }
+</style>
+<h1>All Links</h1>
+<table>
+<tr>
+<th>Owner</th>
+<th>Shortlink</th>
+<th>Destination</th>
+</tr>
+{{range .}}
+<tr>
+<td>{{.Owner}}</td>
+<td><a href="/{{.Display}}">go/{{.Display}}</a></td>
+<td><a href="{{.Destination}}">{{.Destination}}</a></td>
+</tr>
+{{end}}
+</table>
+<br><br><br>
+<p><a href="/">Home</a>

--- a/templates/view.tmpl
+++ b/templates/view.tmpl
@@ -14,10 +14,10 @@
 <th>Shortlink</th>
 <th>Destination</th>
 </tr>
-{{range .}}
+{{range .Links}}
 <tr>
 <td>{{.Owner}}</td>
-<td><a href="/{{.Display}}">go/{{.Display}}</a></td>
+<td><a href="/{{.Display}}">{{$.Prefix}}/{{.Display}}</a></td>
 <td><a href="{{.Destination}}">{{.Destination}}</a></td>
 </tr>
 {{end}}


### PR DESCRIPTION
This creates a page (at `/_/view`) that allows user to view all links in the database. It shows the owner, shortlink, and destination of every link in the loaded link DB.

See the following example:

![Screenshot 2024-08-27 at 22-33-47 gohome - View](https://github.com/user-attachments/assets/66da5b12-0006-4c69-a195-2724164b22cb)
