### PR TITLE
Correct the shortlink name and hostname in the /view handler

### DIFF
--- a/http.go
+++ b/http.go
@@ -107,7 +107,7 @@ func (g *goHttp) handleView(db *LinkDB) error {
 	data := struct {
 		Links  map[string]Link
 		Prefix string
-	}{db.links, *flagHostname}
+	}{db.links, g.R.Host}
 	return executeTmpl(g.W, http.StatusOK, " - View", "view.tmpl", data)
 }
 


### PR DESCRIPTION
The hostname passed via flag might not actually match what's propagated via DNS, so instead use whatever hostname was in the request for the /view page. In addition, use the actual shortlink name rather than the display name, which may differ.